### PR TITLE
Allow config file without env

### DIFF
--- a/choices.gemspec
+++ b/choices.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |gem|
   gem.name    = 'amagimedia-choices'
-  gem.version = '0.4.1'
+  gem.version = '0.5.0'
 
   gem.add_dependency 'hashie', '>= 0.4.0'
   gem.add_development_dependency 'minitest', '~> 5.0.6'

--- a/lib/choices.rb
+++ b/lib/choices.rb
@@ -12,6 +12,10 @@ module Choices
       mash.update local
     end
 
+    if env == "default"
+      return mash
+    end
+
     mash.fetch(env) do
       raise IndexError, %{Missing key for "#{env}" in `#{filename}'}
     end

--- a/test/settings/without_env.yml
+++ b/test/settings/without_env.yml
@@ -1,0 +1,1 @@
+name: 'Defaults'

--- a/test/test_load_settings.rb
+++ b/test/test_load_settings.rb
@@ -14,6 +14,7 @@ describe Choices do
     @with_patch_without_local = path + '../settings/with_patch_without_local.yml'
     @with_patch_with_local = path + '../settings/patch.yml'
     @non_existent_file = path + '../settings/non_existent.yml'
+    @without_env = path + '../settings/without_env.yml'
   end
 
   describe 'when loading from Hash' do
@@ -51,6 +52,10 @@ describe Choices do
         Choices.load_settings(@with_local, 'nonexistent')
       }.must_raise(IndexError)
       error.message.must_equal %{Missing key for "nonexistent" in `#{@with_local}'}
+    end
+
+    it "should load with 'default' env" do
+      Choices.load_settings(@with_local, 'default').name.must_equal 'Defaults'
     end
   end
 


### PR DESCRIPTION
Support environment agnostic config file. 
It can be loaded using `config.from_file('settings.yml, "default")'`